### PR TITLE
Add support for keyUp events

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,18 @@ This addon provides a simple one way input that sends an `update` action when it
   {{one-way-input
       value=currentValue
       update=(action (mut currentValue))
+      onenter=(action "commit")
+      onescape=(action "escape")
   }}
+```
+
+The component's `KEY_EVENTS` attribute can be overwritten to provide custom handlers for various keycodes on the `keyUp` event.
+
+```js
+KEY_EVENTS: {
+  '13': 'onenter',
+  '27': 'onescape'
+}
 ```
 
 ## Why?

--- a/addon/components/one-way-input.js
+++ b/addon/components/one-way-input.js
@@ -34,10 +34,23 @@ export default Component.extend({
     'value',
     'width'
   ],
+  KEY_EVENTS: {
+    '13': 'onenter',
+    '27': 'onescape'
+  },
   _sanitizedValue: undefined,
 
   input() { this._handleChangeEvent(); },
   change() { this._handleChangeEvent(); },
+  keyUp(event) { this._interpretKeyEvents(event); },
+
+  _interpretKeyEvents(event) {
+    const method = this.KEY_EVENTS[event.keyCode];
+
+    if (method) {
+      return this.attrs[method](this.sanitizeInput(this.readDOMAttr('value')));
+    }
+  },
 
   _handleChangeEvent() {
     this._processNewValue.call(this, this.readDOMAttr('value'));

--- a/tests/acceptance/main-test.js
+++ b/tests/acceptance/main-test.js
@@ -24,6 +24,11 @@ test('main test', function(assert) {
   andThen(() => fillIn(INPUT, 'bar'));
   andThen(() => {
     assert.equal(findWithAssert(INPUT).val(), 'bar', 'should update `input` value');
-    assert.equal(findWithAssert('#current-value').text().trim(), 'bar', 'should update `currentValue`');
+    assert.equal(findWithAssert('#current-value').text().trim(), 'bar', 'should update `currentValue` oninput or onchange');
+  });
+  andThen(() => {
+    keyEvent(INPUT, 'keyup', 13).then(() => {
+      assert.equal(findWithAssert('#committed').text().trim(), 'bar', 'should update `committed` onenter');
+    });
   });
 });

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -1,7 +1,14 @@
 import Ember from 'ember';
 
-const { Controller } = Ember;
+const { Controller, set } = Ember;
 
 export default Controller.extend({
-  currentValue: 'foo'
+  committed: null,
+  currentValue: 'foo',
+
+  actions: {
+    commit(value) {
+      set(this, 'committed', value);
+    }
+  }
 });

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -4,10 +4,15 @@
   {{currentValue}}
 </div>
 
+<div id="committed">
+  {{committed}}
+</div>
+
 {{one-way-input
   id="one-way-input"
   value=currentValue
   update=(action (mut currentValue))
+  onenter=(action "commit")
 }}
 
 {{outlet}}


### PR DESCRIPTION
The KEY_EVENTS map can be overwritten to handle custom keycodes for
keyUp events.