### PR TITLE
adding checkbox support

### DIFF
--- a/addon/components/one-way-input.js
+++ b/addon/components/one-way-input.js
@@ -12,6 +12,7 @@ export default Component.extend({
     'accept',
     'autocomplete',
     'autosave',
+    'checked',
     'dir',
     'disabled',
     'formaction',
@@ -49,12 +50,23 @@ export default Component.extend({
     const methodName = this.KEY_EVENTS[event.keyCode];
 
     if (methodName) {
-      this._processNewValue.call(this, methodName, this.readDOMAttr('value'));
+      this._processNewValue.call(this, methodName, this._readAppropriateAttr());
     }
   },
 
   _handleChangeEvent() {
-    this._processNewValue.call(this, 'update', this.readDOMAttr('value'));
+    this._processNewValue.call(this, 'update', this._readAppropriateAttr());
+  },
+
+  _readAppropriateAttr() {
+    let attr;
+    if (get(this, 'type') === 'checkbox') {
+      attr = 'checked';
+    } else {
+      attr = 'value';
+    }
+
+    return this.readDOMAttr(attr);
   },
 
   _processNewValue(methodName, rawValue) {

--- a/tests/acceptance/main-test.js
+++ b/tests/acceptance/main-test.js
@@ -3,7 +3,8 @@ import { module, test } from 'qunit';
 import startApp from '../../tests/helpers/start-app';
 
 const { run } = Ember;
-const INPUT = '#one-way-input';
+const TEXT = '#one-way-text';
+const CHECKBOX = '#one-way-checkbox';
 
 module('Acceptance | main', {
   beforeEach: function() {
@@ -19,18 +20,31 @@ test('main test', function(assert) {
   visit('/');
 
   andThen(() => {
-    assert.equal(findWithAssert(INPUT).val(), 'foo', 'it initializes with a value');
+    assert.equal(findWithAssert(TEXT).val(), 'foo', 'it initializes with a value');
   });
-  andThen(() => fillIn(INPUT, 'bar'));
+  andThen(() => fillIn(TEXT, 'bar'));
   andThen(() => {
-    assert.equal(findWithAssert(INPUT).val(), 'bar', 'should update `input` value');
-    assert.equal(findWithAssert('#current-value').text().trim(), 'bar', 'should update `currentValue` oninput or onchange');
+    assert.equal(findWithAssert(TEXT).val(), 'bar', 'should update `input` value');
+    assert.equal(findWithAssert('#text-current-value').text().trim(), 'bar', 'should update `textCurrentValue` oninput or onchange');
   });
   andThen(() => {
-    keyEvent(INPUT, 'keyup', 13).then(() => {
+    keyEvent(TEXT, 'keyup', 13).then(() => {
       assert.equal(findWithAssert('#committed').text().trim(), 'bar', 'should update `committed` onenter');
     });
-    keyEvent(INPUT, 'keyup', 27);
-    keyEvent(INPUT, 'keyup', 52);
+    keyEvent(TEXT, 'keyup', 27);
+    keyEvent(TEXT, 'keyup', 52);
+  });
+});
+
+test('checkbox test', function(assert) {
+  visit('/');
+
+  andThen(() => {
+    assert.equal(findWithAssert(CHECKBOX).is(':checked'), false, 'it initializes as unchecked');
+  });
+  andThen(() => click(CHECKBOX));
+  andThen(() => {
+    assert.equal(findWithAssert(CHECKBOX).is(':checked'), true, 'should update `input` checked');
+    assert.equal(findWithAssert('#checkbox-current-value').text().trim(), 'true', 'should update `checkboxCurrentValue` onchange');
   });
 });

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -4,7 +4,7 @@ const { Controller, set } = Ember;
 
 export default Controller.extend({
   committed: null,
-  currentValue: 'foo',
+  textCurrentValue: 'foo',
 
   actions: {
     commit(value) {

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,7 +1,7 @@
 <h1>Welcome!</h1>
 
-<div id="current-value">
-  {{currentValue}}
+<div id="text-current-value">
+  {{textCurrentValue}}
 </div>
 
 <div id="committed">
@@ -9,10 +9,21 @@
 </div>
 
 {{one-way-input
-  id="one-way-input"
-  value=currentValue
-  update=(action (mut currentValue))
+  id="one-way-text"
+  value=textCurrentValue
+  update=(action (mut textCurrentValue))
   onenter=(action "commit")
+}}
+
+<div id="checkbox-current-value">
+  {{checkboxCurrentValue}}
+</div>
+
+{{one-way-input
+  id="one-way-checkbox"
+  type="checkbox"
+  value=checkboxCurrentValue
+  update=(action (mut checkboxCurrentValue))
 }}
 
 {{outlet}}


### PR DESCRIPTION
I tried to use as a checkbox, but the value coming back from `update` was always `"on"`. This little PR reads the `checked` attribute in the case the type is `checkbox`.