### PR TITLE
Fix issue with infinite loop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 ---
 language: node_js
 node_js:
-  - "0.12"
+  - "4.1.2"
 
-sudo: false
+sudo: required
+dist: trusty
 
 cache:
   directories:
@@ -11,6 +12,9 @@ cache:
 
 env:
   - EMBER_TRY_SCENARIO=default
+  - EMBER_TRY_SCENARIO=ember-1.13
+  - EMBER_TRY_SCENARIO=ember-2.0
+  - EMBER_TRY_SCENARIO=ember-2.1
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary
@@ -23,7 +27,7 @@ matrix:
 before_install:
   - export PATH=/usr/local/phantomjs-2.0.0/bin:$PATH
   - "npm config set spin false"
-  - "npm install -g npm@^2"
+  - "npm install -g npm@^3"
 
 install:
   - npm install -g bower

--- a/README.md
+++ b/README.md
@@ -14,6 +14,16 @@ This addon provides a simple one way input that sends an `update` action when it
   }}
 ```
 
+The input can also be used as a checkbox:
+
+```hbs
+  {{one-way-input
+      type="checkbox"
+      checked=currentValue
+      update=(action (mut currentValue))
+  }}
+```
+
 The component's `KEY_EVENTS` attribute can be overwritten to provide custom handlers for various keycodes on the `keyUp` event.
 
 ```js
@@ -22,6 +32,8 @@ KEY_EVENTS: {
   '27': 'onescape'
 }
 ```
+
+This means that the `onenter` and `onescape` actions will fire if their corresponding key codes are received in the `keyUp` event.
 
 ## Why?
 
@@ -41,6 +53,10 @@ In the following [demo](http://jsbin.com/juxedi/edit?output), move your cursor t
 ![](https://i.imgur.com/D0pReSs.jpg)
 
 This addon fixes the cursor jumping issue by using [`readDOMAttr`](http://emberjs.com/api/classes/Ember._MetamorphView.html#method_readDOMAttr), which provides a way to read an element's attribute and update the last value Ember knows about at the same time. This makes setting an attribute idempotent.
+
+## Compatibility
+
+This addon will work on Ember versions `1.13.x` and up.
 
 ## Installation
 

--- a/addon/components/one-way-input.js
+++ b/addon/components/one-way-input.js
@@ -47,9 +47,10 @@ export default Component.extend({
   keyUp(event) { this._interpretKeyEvents(event); },
 
   _interpretKeyEvents(event) {
-    const methodName = this.KEY_EVENTS[event.keyCode];
+    let methodName = this.KEY_EVENTS[event.keyCode];
 
     if (methodName) {
+      this._sanitizedValue = null;
       this._processNewValue.call(this, methodName, this._readAppropriateAttr());
     }
   },
@@ -70,15 +71,14 @@ export default Component.extend({
   },
 
   _processNewValue(methodName, rawValue) {
-    const value = this.sanitizeInput(rawValue);
-    const action = this.attrs[methodName];
+    let value = this.sanitizeInput(rawValue);
+    let action = this.attrs[methodName];
 
     if (this._sanitizedValue !== value) {
       this._sanitizedValue = value;
-    }
-
-    if (action) {
-      action(value);
+      if (action) {
+        action(value);
+      }
     }
   },
 
@@ -86,13 +86,13 @@ export default Component.extend({
     return input;
   },
 
+  init() {
+    this._super(...arguments);
+    this._sanitizedValue = get(this, 'value') || get(this, 'checked');
+  },
+
   didReceiveAttrs() {
     this._super(...arguments);
-
-    if (!this.attrs.update) {
-      throw new Error(`You must provide an \`update\` action to \`{{${this.templateName}}}\`.`);
-    }
-
-    this._processNewValue.call(this, 'update', get(this, 'value'));
+    this._processNewValue.call(this, 'update', get(this, 'value') || get(this, 'checked'));
   }
 });

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,8 +1,36 @@
+/*jshint node:true*/
 module.exports = {
   scenarios: [
     {
       name: 'default',
       dependencies: { }
+    },
+    {
+      name: 'ember-1.13',
+      dependencies: {
+        'ember': '~1.13.0'
+      },
+      resolutions: {
+        'ember': '~1.13.0'
+      }
+    },
+    {
+      name: 'ember-2.0',
+      dependencies: {
+        'ember': '~2.0.0'
+      },
+      resolutions: {
+        'ember': '~2.0.0'
+      }
+    },
+    {
+      name: 'ember-2.1',
+      dependencies: {
+        'ember': '~2.1.0'
+      },
+      resolutions: {
+        'ember': '~2.1.0'
+      }
     },
     {
       name: 'ember-release',

--- a/tests/acceptance/main-test.js
+++ b/tests/acceptance/main-test.js
@@ -4,6 +4,7 @@ import startApp from '../../tests/helpers/start-app';
 
 const { run } = Ember;
 const TEXT = '#one-way-text';
+const TEXT_KEYEVENTS = '#one-way-text-keyevents';
 const CHECKBOX = '#one-way-checkbox';
 
 module('Acceptance | main', {
@@ -27,12 +28,22 @@ test('main test', function(assert) {
     assert.equal(findWithAssert(TEXT).val(), 'bar', 'should update `input` value');
     assert.equal(findWithAssert('#text-current-value').text().trim(), 'bar', 'should update `textCurrentValue` oninput or onchange');
   });
+});
+
+test('it responds to key events', function(assert) {
+  visit('/');
+
+  andThen(() => fillIn(TEXT_KEYEVENTS, 'hit enter'));
   andThen(() => {
-    keyEvent(TEXT, 'keyup', 13).then(() => {
-      assert.equal(findWithAssert('#committed').text().trim(), 'bar', 'should update `committed` onenter');
+    keyEvent(TEXT_KEYEVENTS, 'keyup', 13).then(() => {
+      assert.equal(findWithAssert('#committed').text().trim(), 'hit enter', 'should update `committed` onenter');
     });
-    keyEvent(TEXT, 'keyup', 27);
-    keyEvent(TEXT, 'keyup', 52);
+  });
+  andThen(() => fillIn(TEXT_KEYEVENTS, 'hit escape'));
+  andThen(() => {
+    keyEvent(TEXT_KEYEVENTS, 'keyup', 27).then(() => {
+      assert.equal(findWithAssert('#committed').text().trim(), 'hit escape', 'should update `committed` onescape');
+    });
   });
 });
 

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -1,12 +1,13 @@
 import Ember from 'ember';
 
-const { Controller, set } = Ember;
+const { K, Controller, set } = Ember;
 
 export default Controller.extend({
   committed: null,
   textCurrentValue: 'foo',
 
   actions: {
+    noop: K,
     commit(value) {
       set(this, 'committed', value);
     }

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -4,15 +4,22 @@
   {{textCurrentValue}}
 </div>
 
+{{one-way-input
+  id="one-way-text"
+  value=textCurrentValue
+  update=(action (mut textCurrentValue))
+}}
+
 <div id="committed">
   {{committed}}
 </div>
 
 {{one-way-input
-  id="one-way-text"
+  id="one-way-text-keyevents"
   value=textCurrentValue
-  update=(action (mut textCurrentValue))
+  update=(action "noop")
   onenter=(action "commit")
+  onescape=(action "commit")
 }}
 
 <div id="checkbox-current-value">
@@ -22,7 +29,7 @@
 {{one-way-input
   id="one-way-checkbox"
   type="checkbox"
-  value=checkboxCurrentValue
+  checked=checkboxCurrentValue
   update=(action (mut checkboxCurrentValue))
 }}
 


### PR DESCRIPTION
- Remove the new Error thrown when `update` is not passed, as user can
  now pass in other types of actions like `onenter` (responsibility of
  the user to implement an action for the new value)
- Update readme
- Fix issue where user would need to specify both `checked` and `value` for checkboxes

Closes #11, closes #10
Should also close #12, as the action will now only fire if `_sanitizedValue !== rawValue` (set in `didInitAttrs`)